### PR TITLE
Add styles for all cases of missing data

### DIFF
--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
@@ -4,6 +4,19 @@
 </div>
 <table class="table chlist">
   <tbody>
+    <tr *ngIf="providers === null">
+      <td>
+        <div class="loading"><div class="spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+      </td>
+    </tr>
+    <tr *ngIf="providers !== null && !providers.length">
+      <td>
+        <div class="alert alert-warning alert--icon-top alert--icon-top-small">
+          <i class="material-icons">error</i>
+          <span class="alert__text">In order to build a custom XMLTV episode guide you will need to add at least one guide provider. Guide providers ensure you'll get the richest guide data possible.</span>
+        </div>
+      </td>
+    </tr>
     <tr *ngFor="let provider of providers">
       <td class="table__id align-middle"><label class="table__field-label table__field-label--small">ID:</label>{{ provider.ID | number: '2.0' }}</td>
       <td class="table__name align-middle">{{ provider.Name }}</td>
@@ -16,7 +29,7 @@
   </tbody>
 </table>
 
-<button class="btn btn-secondary mt-2 float-right"
+<button class="btn btn-add mt-2 float-right"
 (click)="addProvider()">Add Guide Provider <i class="material-icons">library_add</i></button>
 
 <app-edit-guideprovider-modal

--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
@@ -2,14 +2,14 @@
   <h6 class="table-header__heading"><i class="material-icons table-header__icon">ballot</i>Guide Providers</h6>
   <p class="table-header__body">Guide providers are used to build an XMLTV episode guide for the IPTV channels that Telly serves. Once configured, channels can be mapped to their corresponding guide data.</p>
 </div>
-<table class="table chlist">
+<table class="table">
   <tbody>
-    <tr *ngIf="providers === null">
+    <tr *ngIf="!providers">
       <td>
         <div class="loading"><div class="spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
       </td>
     </tr>
-    <tr *ngIf="providers !== null && !providers.length">
+    <tr *ngIf="providers && !providers.length">
       <td>
         <div class="alert alert-warning alert--icon-top alert--icon-top-small">
           <i class="material-icons">error</i>

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
@@ -2,7 +2,7 @@
   <h6 class="table-header__heading"><i class="material-icons table-header__icon">live_tv</i>Video Providers</h6>
   <p class="table-header__body">Video providers are used by Telly to build a channel lineup to be served to Plex. Multiple providers can be added and used to create one or more lineups.</p>
 </div>
-<table class="table chlist">
+<table class="table">
   <tbody>
     <tr *ngIf="providers === null">
       <td>

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
@@ -4,6 +4,19 @@
 </div>
 <table class="table chlist">
   <tbody>
+    <tr *ngIf="providers === null">
+      <td>
+        <div class="loading"><div class="spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+      </td>
+    </tr>
+    <tr *ngIf="providers !== null && !providers.length">
+      <td>
+        <div class="alert alert-warning alert--icon-top alert--icon-top-small">
+          <i class="material-icons">warning</i>
+          <span class="alert__text">Seems you haven't added any video providers yet. Video providers are the source of your streams, you're nothing without them!</span>
+        </div>
+      </td>
+    </tr>
     <tr *ngFor="let provider of providers">
       <td class="table__id align-middle"><label class="table__field-label table__field-label--small">ID:</label>{{ provider.ID | number: '2.0' }}</td>
       <td class="table__name align-middle">{{ provider.Name }}</td>
@@ -16,7 +29,7 @@
 </table>
 
 
-<button class="btn btn-secondary mt-2 float-right"
+<button class="btn btn-add mt-2 float-right"
 (click)="addProvider()">Add Video Provider <i class="material-icons">library_add</i></button>
 
 <app-edit-videoprovider-modal

--- a/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
+++ b/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
@@ -8,7 +8,7 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <button class="btn btn-add mb-4" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button>
+      <button class="btn btn-add mb-4 float-right" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button>
       <div class="alert alert-warning alert--icon-top alert--icon-top-large" *ngIf="!(lineups$ | async)">
         <i class="material-icons">warning</i>
         <span class="alert__text">Whoops! Looks like you haven't created any lineups yet. Head over to the <a routerLink="/lineup/manage" title="Manage">manage</a> page to create one now. If you haven't already, be sure that you have at least one video provider <a routerLink="/config" title="Configuration">configured</a>.</span>

--- a/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
+++ b/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
@@ -8,7 +8,12 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <button class="btn btn-secondary mb-4" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button>
+      <button class="btn btn-add mb-4" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button>
+      <div class="alert alert-warning alert--icon-top alert--icon-top-large" *ngIf="!(lineups$ | async)">
+        <i class="material-icons">warning</i>
+        <span class="alert__text">Whoops! Looks like you haven't created any lineups yet. Head over to the <a routerLink="/lineup/manage" title="Manage">manage</a> page to create one now. If you haven't already, be sure that you have at least one video provider <a routerLink="/config" title="Configuration">configured</a>.</span>
+        <div class="alert__button"><button class="btn btn-add btn-lg" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button></div>
+      </div>
       <table class="table chlist">
         <tbody>
           <tr *ngFor="let lineup of (lineups$ | async)">

--- a/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
+++ b/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.html
@@ -14,7 +14,7 @@
         <span class="alert__text">Whoops! Looks like you haven't created any lineups yet. Head over to the <a routerLink="/lineup/manage" title="Manage">manage</a> page to create one now. If you haven't already, be sure that you have at least one video provider <a routerLink="/config" title="Configuration">configured</a>.</span>
         <div class="alert__button"><button class="btn btn-add btn-lg" (click)="addLineup()">Add New Lineup <i class="material-icons">add_to_queue</i></button></div>
       </div>
-      <table class="table chlist">
+      <table class="table">
         <tbody>
           <tr *ngFor="let lineup of (lineups$ | async)">
             <!-- {{ channel | json }} -->

--- a/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.scss
+++ b/src/app/lineup/components/lineup-manager-overview/lineup-manager-overview.component.scss
@@ -1,3 +1,0 @@
-a {
-  color: black;
-}

--- a/src/app/lineup/components/lineup-manager/lineup-manager.component.html
+++ b/src/app/lineup/components/lineup-manager/lineup-manager.component.html
@@ -10,13 +10,21 @@
     <div class="col">
       <div *ngIf="!lineup.Channels || !(lineup.Channels.length >= 420)" class="mb-4">
         <button class="btn btn-secondary mr-2" routerLink="/lineup/manage"><i class="material-icons">arrow_back</i> Back to overview</button>
-        <button class="btn btn-secondary float-right" (click)="addChannel()">Add Channel <i class="material-icons">add_to_queue</i></button>
+        <button class="btn btn-add float-right" (click)="addChannel()">Add Channel <i class="material-icons">add_to_queue</i></button>
       </div>
-      <div *ngIf="lineup.Channels.length >= 420" class="alert alert-danger">
-        WARNING: Plex cannot handle more than 420 channels, adding more channels is disabled for your own protection.
+      <div *ngIf="lineup.Channels.length >= 420" class="alert alert--icon-side alert--icon-side-left alert-danger">
+        <i class="material-icons">warning</i>
+        <span class="alert__text"><strong>WARNING:</strong> Plex cannot handle more than 420 channels, adding more channels is disabled for your own protection.</span>
       </div>
 
-      <div class="table__wrap">
+
+      <div class="alert alert-warning alert--icon-top alert--icon-top-large" *ngIf="!lineup || !lineup.Channels || !lineup.Channels.length">
+        <i class="material-icons">warning</i>
+        <span class="alert__text">Whoops! Looks like you haven't added any channels yet. You're in the right place though! Click either <a [routerLink]="" (click)="addChannel()" title="Add Channel">Add Channel</a> button on this page to get started.</span>
+        <div class="alert__button"><button class="btn btn-add btn-lg" (click)="addChannel()">Add Channel <i class="material-icons">add_to_queue</i></button></div>
+      </div>
+
+      <div *ngIf="lineup && lineup.Channels && lineup.Channels.length" class="table__wrap">
         <table class="table chlist">
           <thead>
             <tr>
@@ -29,7 +37,7 @@
             <tr class="table-row--draggable" *ngFor="let channel of lineup.Channels">
               <!-- {{ channel | json }} -->
               <td class="table__id align-middle"><i class="material-icons">drag_indicator</i>{{ channel.ChannelNumber | number: '3.0-0' }}</td>
-              <td *ngIf="channel.GuideChannel && channel.GuideChannel.Data && channel.GuideChannel.Logos && channel.GuideChannel.Data.Logos[0] && channel.GuideChannel.Data.Logos[0].URL" class="table__image align-middle"><img src="{{channel.GuideChannel.Data.Logos[0].URL}}" /></td>
+              <td *ngIf="channel.GuideChannel && channel.GuideChannel.Data && channel.GuideChannel.Data.Logos && channel.GuideChannel.Data.Logos[0] && channel.GuideChannel.Data.Logos[0].URL" class="table__image align-middle"><img src="{{channel.GuideChannel.Data.Logos[0].URL}}" /></td>
               <td *ngIf="!channel.VideoTrack || channel.VideoTrack && !channel.VideoTrack.Logo" class="table__image align-middle">
                 <svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000" preserveAspectRatio="xMidYMid meet">
                     <g transform="translate(0.000000,512.000000) scale(0.100000,-0.100000)"
@@ -68,8 +76,8 @@
       </div>
     </div>
   </div>
-  <div class="mt-4 float-right">
-    <div class="alert alert-warning"><span class="alert__text">When saving channels, the tuner will reload and any stream/recording in Plex will be stopped.</span><i class="material-icons">warning</i></div>
+  <div *ngIf="lineup && lineup.Channels && lineup.Channels.length" class="mt-4 float-right">
+    <div class="alert alert-warning alert--icon-side alert--icon-side-right"><span class="alert__text">When saving channels, the tuner will reload and any stream/recording in Plex will be stopped.</span><i class="material-icons">warning</i></div>
     <button type="button" class="btn btn-primary float-right" (click)="saveChannels()">Save all changes</button>
   </div>
 </div>

--- a/src/app/lineup/components/lineup-manager/lineup-manager.component.html
+++ b/src/app/lineup/components/lineup-manager/lineup-manager.component.html
@@ -25,7 +25,7 @@
       </div>
 
       <div *ngIf="lineup && lineup.Channels && lineup.Channels.length" class="table__wrap">
-        <table class="table chlist">
+        <table class="table">
           <thead>
             <tr>
               <th scope="col">CH. No</th>

--- a/src/app/lineup/components/lineup-manager/lineup-manager.component.html
+++ b/src/app/lineup/components/lineup-manager/lineup-manager.component.html
@@ -38,7 +38,7 @@
               <!-- {{ channel | json }} -->
               <td class="table__id align-middle"><i class="material-icons">drag_indicator</i>{{ channel.ChannelNumber | number: '3.0-0' }}</td>
               <td *ngIf="channel.GuideChannel && channel.GuideChannel.Data && channel.GuideChannel.Data.Logos && channel.GuideChannel.Data.Logos[0] && channel.GuideChannel.Data.Logos[0].URL" class="table__image align-middle"><img src="{{channel.GuideChannel.Data.Logos[0].URL}}" /></td>
-              <td *ngIf="!channel.VideoTrack || channel.VideoTrack && !channel.VideoTrack.Logo" class="table__image align-middle">
+              <td *ngIf="!channel.GuideChannel || channel.GuideChannel && channel.GuideChannel.Data && channel.GuideChannel.Data.Logos && !channel.GuideChannel.Data.Logos.length" class="table__image align-middle">
                 <svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000" preserveAspectRatio="xMidYMid meet">
                     <g transform="translate(0.000000,512.000000) scale(0.100000,-0.100000)"
                     fill="#000000" stroke="none">

--- a/src/app/lineup/components/lineup-overview/lineup-overview.component.html
+++ b/src/app/lineup/components/lineup-overview/lineup-overview.component.html
@@ -6,6 +6,13 @@
 </div>
 
 <div class="container">
+
+  <div class="alert alert-warning alert--icon-top alert--icon-top-large" *ngIf="!(lineups$ | async)">
+    <i class="material-icons">warning</i>
+    <span class="alert__text">Whoops! Looks like you haven't created any lineups yet. Head over to the <a routerLink="/lineup/manage" title="Manage">manage</a> page to create one now. If you haven't already, be sure that you have at least one video provider <a routerLink="/config" title="Configuration">configured</a>.</span>
+    <div class="alert__button"><button class="btn btn-lg btn-primary" routerLink="/lineup/manage">Manage Lineups</button></div>
+  </div>
+
   <div *ngFor="let lineup of (lineups$ | async)" class="row mb-4">
 
     <p *ngIf="!lineup.Channels || lineup.Channels.length === 0" class="col-12 pl-0">

--- a/src/app/lineup/components/lineup-overview/lineup-overview.component.html
+++ b/src/app/lineup/components/lineup-overview/lineup-overview.component.html
@@ -20,7 +20,7 @@
     </p>
     <div class="table__wrap">
       <h4 class="page-heading page-heading__no-transform"><i class="material-icons mr-2">view_list</i> {{ lineup.Name }}</h4>
-      <table class="table chlist">
+      <table class="table">
         <thead>
           <tr>
             <th scope="col">CH. No</th>

--- a/src/app/preview-lineup/components/preview-guideprovider-lineup/preview-guideprovider-lineup.component.html
+++ b/src/app/preview-lineup/components/preview-guideprovider-lineup/preview-guideprovider-lineup.component.html
@@ -6,22 +6,24 @@
 </div>
 
 <div class="container">
-  <table class="table">
-   <thead>
-    <tr>
-      <th scope="col">Number</th>
-      <th scope="col">Name</th>
-      <th scope="col">Call Sign</th>
-      <th scope="col">Affilate</th>
-    </tr>
-   </thead>
-   <tbody>
-    <tr *ngFor="let channel of (channels$ | async)">
-      <td>{{ channel.Number }}</td>
-      <td>{{ channel.Name }}</td>
-      <td>{{ channel.CallSign }}</td>
-      <td>{{ channel.Affiliate }}</td>
-    </tr>
-   </tbody>
-  </table>
+  <div class="table__wrap">
+    <table class="table">
+     <thead>
+      <tr>
+        <th scope="col">CH No.</th>
+        <th scope="col">CH Name</th>
+        <th scope="col">Call Sign</th>
+        <th scope="col">Affilate</th>
+      </tr>
+     </thead>
+     <tbody>
+      <tr *ngFor="let channel of (channels$ | async)">
+        <td class="table__id">{{ channel.Number }}</td>
+        <td class="table__name">{{ channel.Name }}</td>
+        <td class="table__name table__name--mono">{{ channel.CallSign }}</td>
+        <td class="table__name table__name--mono " [ngClass]="{ table__affliate: channel.Affiliate }">{{ channel.Affiliate }}</td>
+      </tr>
+     </tbody>
+    </table>
+  </div>
 </div>

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -2,12 +2,14 @@
 $colors--aqua: #4ECDC4;
 $colors--aqua-highlight: #6ff2e8;
 $colors--black: #000000;
+$colors--green: #4ecd85;
+$colors--green-highlight: #70e5a3;
 $colors--grey1: #dee2e6;
 $colors--grey2: #c6c6c6;
 $colors--grey3: #a5a5a5;
 $colors--offwhite-0: #f9f9f9;
 $colors--offwhite-1: #f2f2f2;
-$colors--orange: #FA6900;
+$colors--orange: #cd6c4e;
 $colors--red: #e04343;
 $colors--slate: #556270;
 $colors--white: #ffffff;

--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -60,6 +60,25 @@
   }
 }
 
+.table__name--mono {
+  font-family: $fonts--sharetech;
+}
+
+.table__affliate {
+  color: $colors--orange;
+  position: relative;
+  &:before {
+    content: 'arrow_forward';
+    color: #4ecd85;
+    display: block;
+    font-family: 'Material Icons';
+    position: absolute;
+    top: 11px;
+    left: -20px;
+  }
+}
+
+
 .table__image {
   width: 8%;
   font-family: $fonts--sharetech;
@@ -76,7 +95,7 @@
   }
 
   img {
-    height: 30px;
+    height: 45px;
   }
 
   svg {

--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -53,7 +53,6 @@
 }
 
 .table__name {
-  width: 100%;
   padding-top: 12px !important;
 
   .badge {
@@ -62,7 +61,7 @@
 }
 
 .table__image {
-  width: 10%;
+  width: 8%;
   font-family: $fonts--sharetech;
   font-size: 10px;
   padding-left: 20px !important;
@@ -77,7 +76,7 @@
   }
 
   img {
-    height: 75px;
+    height: 30px;
   }
 
   svg {
@@ -160,6 +159,7 @@
 }
 
 .table__wrap {
+  width: 100%;
   background: $colors--offwhite-1;
   border-radius: 2px;
   padding: 10px;
@@ -198,9 +198,9 @@
 .table-row--draggable {
   cursor: grab;
 
-  .table__image {
-    width: 15%;
-  }
+  // .table__image {
+  //   width: 15%;
+  // }
 
   td {
     transition: background 0.5s ease, box-shadow 0.25s ease 0.15s, color 0.5s ease;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -9,6 +9,16 @@ html, body {
   font-family: $fonts--roboto;
 }
 
+a {
+  color: $colors--orange;
+  transition: color 0.25s ease;
+
+  &:hover {
+    color: $colors--slate;
+    text-decoration: none;
+  }
+}
+
 // Heading Tags (h1-h6)
 .page-heading {
   align-items: center;
@@ -132,7 +142,9 @@ Bootstrap Overrides
   text-transform: uppercase;
 
   .material-icons {
-    font-size: inherit;
+    display: inline-block !important;
+    font-size: inherit !important;
+    margin: 0 !important;
     position: relative;
     top: 2px;
   }
@@ -143,6 +155,17 @@ Bootstrap Overrides
   &:hover {
     background-color: $colors--aqua-highlight;
     border-color: $colors--aqua;
+    color: $colors--slate;
+  }
+}
+
+.btn-add {
+  background-color: $colors--green;
+  border-color: $colors--green;
+  color: $colors--white;
+  &:hover {
+    background-color: $colors--green-highlight;
+    border-color: $colors--green;
     color: $colors--slate;
   }
 }
@@ -215,18 +238,73 @@ label {
 
 // Warnings
 .alert {
-  align-items: center;
   border-radius: 2px;
+}
+
+.alert--icon-side {
+  align-items: center;
   display: flex;
-  flex-direction: row;
   font-size: 12px;
+  flex-direction: row;
   justify-content: center;
+}
+
+.alert--icon-side-left {
   // Styles Material-Icons icons within alerts
-  i {
+  .material-icons {
+    margin-right: 15px
+  }
+}
+
+.alert--icon-side-right {
+  // Styles Material-Icons icons within alerts
+  .material-icons {
     margin-left: 15px
   }
 }
 
+.alert--icon-top {
+  align-items: center;
+  display: flex;
+  font-size: 12px;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+
+  p {
+    color: $colors--slate;
+    display: block;
+  }
+  .alert__button {
+    width: 100%;
+    margin: 15px 0 0;
+  }
+  .material-icons {
+    display: block;
+  }
+}
+
+.alert--icon-top-large {
+  p {
+    margin: 0 0 20px;
+  }
+
+  .material-icons {
+    font-size: 50px;
+    margin: 0 0 10px;
+  }
+}
+
+.alert--icon-top-small {
+  p {
+    margin: 0 0 20px;
+  }
+
+  .material-icons {
+    font-size: 22px;
+    margin: 0 0 10px;
+  }
+}
 
 // Misc
 .pointer {
@@ -240,4 +318,89 @@ label {
 .modal-show {
   display: block;
   background-color: rgba(140, 140, 140, .6);
+}
+
+//Loading
+.loading {
+  width: 100%;
+  text-align: center;
+}
+.spinner {
+  color: official;
+  display: inline-block;
+  position: relative;
+  width: 64px;
+  height: 64px;
+  transform: scale(0.5);
+}
+.spinner div {
+  transform-origin: 32px 32px;
+  animation: spinner 1.2s linear infinite;
+}
+.spinner div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 3px;
+  left: 29px;
+  width: 5px;
+  height: 14px;
+  border-radius: 20%;
+  background: $colors--aqua;
+}
+.spinner div:nth-child(1) {
+  transform: rotate(0deg);
+  animation-delay: -1.1s;
+}
+.spinner div:nth-child(2) {
+  transform: rotate(30deg);
+  animation-delay: -1s;
+}
+.spinner div:nth-child(3) {
+  transform: rotate(60deg);
+  animation-delay: -0.9s;
+}
+.spinner div:nth-child(4) {
+  transform: rotate(90deg);
+  animation-delay: -0.8s;
+}
+.spinner div:nth-child(5) {
+  transform: rotate(120deg);
+  animation-delay: -0.7s;
+}
+.spinner div:nth-child(6) {
+  transform: rotate(150deg);
+  animation-delay: -0.6s;
+}
+.spinner div:nth-child(7) {
+  transform: rotate(180deg);
+  animation-delay: -0.5s;
+}
+.spinner div:nth-child(8) {
+  transform: rotate(210deg);
+  animation-delay: -0.4s;
+}
+.spinner div:nth-child(9) {
+  transform: rotate(240deg);
+  animation-delay: -0.3s;
+}
+.spinner div:nth-child(10) {
+  transform: rotate(270deg);
+  animation-delay: -0.2s;
+}
+.spinner div:nth-child(11) {
+  transform: rotate(300deg);
+  animation-delay: -0.1s;
+}
+.spinner div:nth-child(12) {
+  transform: rotate(330deg);
+  animation-delay: 0s;
+}
+@keyframes spinner {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
- Add styles for all cases of missing data
- Change some button color/positioning for consistency
- Add loading spinners for config page

HELP! – Seems like my markup that is supposed to show when data is missing kind of flashes into view before showing the actual data (lineup or channel manager for example). Any ideas there?

Note: I don't know if @robbiet480 changed the size of the logos intentionally, but I change them back to be smaller for 2 reasons.. One being that if we do want to change the size, I'll have to resize the buttons and some of the other text to make it all work together.. Also, once your channel list is over 40 all that extra image space adds a lot of scrolling.