### PR TITLE
Configuration: Guide & Video Provider Save/Delete methods

### DIFF
--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
@@ -36,7 +36,8 @@
   [newProvider]="addingProvider"
   [provider]="editingProvider"
   (close)="closeModal()"
-  (create)="createProvider()">
+  (create)="createProvider()"
+  (save)="saveProvider()">
 </app-edit-guideprovider-modal>
 
 <app-edit-guideprovider-lineups-modal

--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.html
@@ -23,7 +23,7 @@
       <td class="table__actions align-middle">
         <a class="table__action table__action--edit_lineup pointer" (click)="editingProviderLineups = provider; editLineups = true"><i class="material-icons">view_list</i></a>
         <a class="table__action pointer" (click)="editingProvider = provider"><i class="material-icons">edit</i></a>
-        <a class="table__action table__action--delete pointer" (click)="removeProvider(channel)"><i class="material-icons">delete_forever</i></a>
+        <a class="table__action table__action--delete pointer" (click)="removeProvider(provider)"><i class="material-icons">delete_forever</i></a>
       </td>
     </tr>
   </tbody>

--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.ts
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.ts
@@ -43,4 +43,11 @@ export class ConfigurationGuideProviderComponent {
     });
     this.closeModal();
   }
+
+  removeProvider(provider: IGuideSource): void {
+    this.configService.deleteGuideProvider(provider).subscribe(() => {
+      const index = this.providers.findIndex((d: IGuideSource) => d.ID === provider.ID);
+      this.providers.splice(index, 1);
+    });
+  }
 }

--- a/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.ts
+++ b/src/app/configuration/components/configuration-guideprovider/configuration-guideprovider.component.ts
@@ -40,8 +40,14 @@ export class ConfigurationGuideProviderComponent {
   createProvider(): void {
     this.configService.createGuideProvider(this.editingProvider as ICreateGuideProvider).subscribe((provider: IGuideSource) => {
       this.providers.push(provider);
+      this.closeModal();
     });
-    this.closeModal();
+  }
+
+  saveProvider(): void {
+    this.configService.saveGuideProvider(this.editingProvider as IGuideSource).subscribe(() => {
+      this.closeModal();
+    });
   }
 
   removeProvider(provider: IGuideSource): void {

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
@@ -36,5 +36,6 @@
   [newProvider]="addingProvider"
   [provider]="editingProvider"
   (close)="closeModal()"
-  (create)="createProvider()">
+  (create)="createProvider()"
+  (save)="saveProvider()">
 </app-edit-videoprovider-modal>

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.html
@@ -22,7 +22,7 @@
       <td class="table__name align-middle">{{ provider.Name }}</td>
       <td class="table__actions align-middle">
         <a class="table__action pointer" (click)="editingProvider = provider"><i class="material-icons">edit</i></a>
-        <a class="table__action table__action--delete pointer" (click)="removeProvider(channel)"><i class="material-icons">delete_forever</i></a>
+        <a class="table__action table__action--delete pointer" (click)="removeProvider(provider)"><i class="material-icons">delete_forever</i></a>
       </td>
     </tr>
   </tbody>

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
@@ -33,13 +33,14 @@ export class ConfigurationVideoProviderComponent {
   createProvider(): void {
     this.configService.createVideoProvider(this.editingProvider as ICreateVideoProvider).subscribe((provider: IVideoSource) => {
       this.providers.push(provider);
+      this.closeModal();
     });
-    this.closeModal();
   }
 
   saveProvider(): void {
-    this.configService.saveVideoProvider(this.editingProvider as IVideoSource).subscribe();
-    this.closeModal();
+    this.configService.saveVideoProvider(this.editingProvider as IVideoSource).subscribe(() => {
+      this.closeModal();
+    });
   }
 
   removeProvider(provider: IVideoSource): void {

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
@@ -36,4 +36,8 @@ export class ConfigurationVideoProviderComponent {
     });
     this.closeModal();
   }
-}
+
+  saveProvider(): void {
+    this.configService.saveVideoProvider(this.editingProvider as IVideoSource).subscribe();
+    this.closeModal();
+  }

--- a/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
+++ b/src/app/configuration/components/configuration-videoprovider/configuration-videoprovider.component.ts
@@ -41,3 +41,11 @@ export class ConfigurationVideoProviderComponent {
     this.configService.saveVideoProvider(this.editingProvider as IVideoSource).subscribe();
     this.closeModal();
   }
+
+  removeProvider(provider: IVideoSource): void {
+    this.configService.deleteVideoProvider(provider).subscribe(() => {
+      const index = this.providers.findIndex((d: IVideoSource) => d.ID === provider.ID);
+      this.providers.splice(index, 1);
+    });
+  }
+}

--- a/src/app/configuration/components/edit-guideprovider-modal/edit-guideprovider-modal.component.html
+++ b/src/app/configuration/components/edit-guideprovider-modal/edit-guideprovider-modal.component.html
@@ -40,8 +40,8 @@
         <button type="button" class="btn btn-primary" (click)="this.create.emit()">Add Provider</button>
       </div>
       <div *ngIf="!newProvider" class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="this.close.emit()">Close</button>
-        <button type="button" class="btn btn-primary" (click)="this.save.emit()">Add Provider</button>
+        <button type="button" class="btn btn-secondary" (click)="this.close.emit()">Close</button>
+        <button type="button" class="btn btn-primary" (click)="this.save.emit()">Save Provider</button>
       </div>
     </div>
   </div>

--- a/src/app/configuration/components/edit-videoprovider-modal/edit-videoprovider-modal.component.html
+++ b/src/app/configuration/components/edit-videoprovider-modal/edit-videoprovider-modal.component.html
@@ -31,7 +31,7 @@
           </div>
           <div *ngIf="provider.Provider == 'Xtream'" class="form-group">
             <label for="baseurl">Provider URL</label>
-            <input type="url" class="form-control" id="baseurl" name="baseurl" placeholder="http://irislinks.net:83" [(ngModel)]="provider.BaseUrl">
+            <input type="url" class="form-control" id="baseurl" name="baseurl" placeholder="http://irislinks.net:83" [(ngModel)]="provider.BaseURL">
           </div>
           <div *ngIf="provider.Provider == 'M3U'" class="form-group">
             <label for="M3UURL">Path to or URL of M3U file</label>

--- a/src/app/configuration/components/edit-videoprovider-modal/edit-videoprovider-modal.component.html
+++ b/src/app/configuration/components/edit-videoprovider-modal/edit-videoprovider-modal.component.html
@@ -61,8 +61,8 @@
         <button type="button" class="btn btn-primary" (click)="this.create.emit()">Add Provider</button>
       </div>
       <div *ngIf="!newProvider" class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="this.close.emit()">Close</button>
-        <button type="button" class="btn btn-primary" (click)="this.save.emit()">Add Provider</button>
+        <button type="button" class="btn btn-secondary" (click)="this.close.emit()">Close</button>
+        <button type="button" class="btn btn-primary" (click)="this.save.emit()">Save Provider</button>
       </div>
     </div>
   </div>

--- a/src/app/configuration/models/createVideoProvider.model.ts
+++ b/src/app/configuration/models/createVideoProvider.model.ts
@@ -3,7 +3,7 @@ export interface ICreateVideoProvider {
   Provider: VideoProvider;
 
   // XTream
-  BaseUrl?: string;
+  BaseURL?: string;
   Username?: string;
   Password?: string;
 

--- a/src/app/configuration/services/configuration.service.ts
+++ b/src/app/configuration/services/configuration.service.ts
@@ -36,6 +36,10 @@ export class ConfigurationService {
     return this.http.put<IGuideSource>(`${this.url}/guide_sources/${provider.ID}`, provider);
   }
 
+  deleteGuideProvider(provider: IGuideSource): Observable<{}> {
+    return this.http.delete(`${this.url}/guide_sources/${provider.ID}`);
+  }
+
   getGuideProviders(): Observable<IGuideSource[]> {
     return this.guideSourceService.getGuideSources();
   }
@@ -49,6 +53,11 @@ export class ConfigurationService {
   saveVideoProvider(provider: IVideoSource): Observable<IVideoSource> {
     return this.http.put<IVideoSource>(`${this.url}/video_sources/${provider.ID}`, provider);
   }
+
+  deleteVideoProvider(provider: IVideoSource): Observable<{}> {
+    return this.http.delete(`${this.url}/video_sources/${provider.ID}`);
+  }
+
   getVideoProviders(): Observable<IVideoSource[]> {
     return this.videoSourceService.getVideoSources();
   }

--- a/src/app/configuration/services/configuration.service.ts
+++ b/src/app/configuration/services/configuration.service.ts
@@ -26,18 +26,29 @@ export class ConfigurationService {
     private videoSourceService: VideoSourceService,
   ) { }
 
+  // Guide provider methods
+
   createGuideProvider(provider: ICreateGuideProvider): Observable<IGuideSource> {
     return this.http.post<IGuideSource>(`${this.url}/guide_sources`, provider);
+  }
+
+  saveGuideProvider(provider: IGuideSource): Observable<IGuideSource> {
+    return this.http.put<IGuideSource>(`${this.url}/guide_sources/${provider.ID}`, provider);
   }
 
   getGuideProviders(): Observable<IGuideSource[]> {
     return this.guideSourceService.getGuideSources();
   }
 
+  // Video provider methods
+
   createVideoProvider(provider: ICreateVideoProvider): Observable<IVideoSource> {
     return this.http.post<IVideoSource>(`${this.url}/video_sources`, provider);
   }
 
+  saveVideoProvider(provider: IVideoSource): Observable<IVideoSource> {
+    return this.http.put<IVideoSource>(`${this.url}/video_sources/${provider.ID}`, provider);
+  }
   getVideoProviders(): Observable<IVideoSource[]> {
     return this.videoSourceService.getVideoSources();
   }


### PR DESCRIPTION
Depends on #14 to be merged into master, as well as the HTTP methods merged into the main repo.

Fixes #13 and #11 

* Adds saving and deletion to guide & video providers.
* Close modals after subscriptions instead of immediately, helps better illustrate if there is an error.

Depends on the following HTTP methods in the Telly API:

* `PUT guide_sources/id`
* `PUT video_sources/id`
* `DELETE guide_sources/id`
* `DELETE video_sources/id`

These will be in a pull request in the main repo shortly after this PR is submitted.